### PR TITLE
📝 Add CTA to README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Browse [Zerion](https://app.zerion.io/explore) via Raycast.
 
+<p align="center"><a title="Install zerion Raycast Extension" href="https://www.raycast.com/qdqd/zerion"><img src="https://www.raycast.com/qdqd/zerion/install_button@2x.png?v=1.1" height="64" alt="" style="height: 64px;"></a></p>
+
 ![Extension screenshot](./metadata/zerion-1.png)
 
 Monitor any account directly in the Raycast!


### PR DESCRIPTION
It adds a button in the README file that allows users to install the Raycast extension directly from the repository.